### PR TITLE
Add login POST Request 

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,7 +5,7 @@ import { json } from 'body-parser';
 import helmet from 'helmet';
 import cookieParser from 'cookie-parser';
 import { signupRouter } from './routes/signup';
-
+import { loginRouter } from './routes/login';
 // Initialize express.
 const app = express();
 
@@ -20,6 +20,7 @@ app.use(helmet());
 
 // Add routes.
 app.use(signupRouter);
+app.use(loginRouter);
 
 // Export the app and environment variables.
 export { app, NODE_ENV, PORT, ORIGIN, MONGO_URI, JWT_KEY };

--- a/src/routes/login.ts
+++ b/src/routes/login.ts
@@ -1,0 +1,53 @@
+import { Request, Response } from 'express';
+import { body } from 'express-validator';
+import jwt from 'jsonwebtoken';
+import { User } from '../models';
+import { PasswordManager } from '../util/hash/index';
+
+const loginRouter = require('express').Router();
+
+loginRouter.post(
+  '/api/v1/users/login',
+  [
+    body('username').isLength({ min: 1, max: 20 }).escape(),
+    body('email').isLength({ max: 30 }).isEmail().escape(),
+    body('password').isLength({ min: 2, max: 20 }).escape(),
+  ],
+  async (req: Request, res: Response) => {
+    const reqbody = req.body;
+    // Find User in Database
+    const user = await User.findOne({ username: reqbody.username });
+    const passwordCorrect =
+      user === null
+        ? false
+        : await PasswordManager.compare(user.password, reqbody.password);
+    // Return error is user does not exist or password is incorrect
+    if (!(user && passwordCorrect)) {
+      res.status(401).json({
+        error: 'invalid username or password',
+      });
+    }
+    // username & password are correct
+    else {
+      // create a jwt
+      const userJwt = jwt.sign(
+        {
+          id: user.id,
+          email: user.email,
+          username: user.username,
+        },
+        process.env.JWT_KEY!,
+        { expiresIn: 60 * 60 }
+      );
+      res
+        .status(200)
+        .cookie('access_token', userJwt, {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === 'production',
+        })
+        .json(user);
+    }
+  }
+);
+
+export { loginRouter };


### PR DESCRIPTION
This pull request aims to handle issue #50: POST login route. 

The code attempts to follow the following workflow.

Create a route in src/routes/login.ts

I followed along with jesses routing & express validators for the request body.
Then confirm user is in database & confirm correct password is provided. 
If both conditions are met create jwt set to expire in 60 minutes. I propose we discuss how to handle the duration the user has access to this in the next sprint(s)

Finally send response code, json of ( username, email, & password) and a cookie with jwt access token for subsequent request to the server. 

I tested the route in postman as shown below.
Let me know what I can improve upon!

<img width="1405" alt="image" src="https://user-images.githubusercontent.com/75345541/156214777-1a145d75-ac57-4be0-95f2-90c92c856d31.png">

